### PR TITLE
[#151838550] Add Concourse task for CI

### DIFF
--- a/ci/integration.yml
+++ b/ci/integration.yml
@@ -1,0 +1,16 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: alpine
+    tag: "3.4"
+inputs:
+  - name: repo
+run:
+  path: sh
+  args:
+    - -e
+    - -c
+    - |
+      echo "skipping, the tests are running on Travis: https://travis-ci.org/alphagov/paas-usage-events-collector"


### PR DESCRIPTION
## What

To add this repository to our CI pipelines we need to define a Concourse task
in ci/integration.yml. For now we don't run the tests on our CI server as they
require a Postgres instance running and we would need to build a custom Docker
image for this. Currently we'll depend on Travis running the tests for us.

## How to review

I ran the integration-test task for this on my dev CI, so I think a sanity check should be enough.

## Who can review

not me
