### PR TITLE
[#153435158] Create a statement/report endpoint for the Billing API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -44,7 +44,7 @@ func NewReportHandler(db db.SQLClient) echo.HandlerFunc {
 			with
 			resources as (
 				select
-					guid,
+					name,
 					space_guid,
 					pricing_plan_id,
 					pricing_plan_name,
@@ -55,9 +55,9 @@ func NewReportHandler(db db.SQLClient) echo.HandlerFunc {
 				where
 					org_guid = $1
 				group by
-					guid, space_guid, pricing_plan_id, pricing_plan_name
+					name, space_guid, pricing_plan_id, pricing_plan_name
 				order by
-					guid, space_guid, pricing_plan_id
+					name, space_guid, pricing_plan_id
 			),
 			space_resources as (
 				select

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -848,7 +848,31 @@ var _ = Describe("API", func() {
 					EntityRaw: json.RawMessage(`{
 						"state": "STOPPED",
 						"app_guid": "o1s1-app1",
+						"app_name": "o1s1-app1-renamed",
+						"org_guid": "o1",
+						"space_guid": "o1s1",
+						"instance_count": 2,
+						"memory_in_mb_per_instance": 512,
+						"previous_state": "STARTED"
+					}`),
+				}, {
+					MetaData: cf.MetaData{CreatedAt: now.Add(-58 * time.Minute)},
+					EntityRaw: json.RawMessage(`{
+						"state": "STARTED",
+						"app_guid": "o1s1-app2",
 						"app_name": "o1s1-app1",
+						"org_guid": "o1",
+						"space_guid": "o1s1",
+						"instance_count": 2,
+						"memory_in_mb_per_instance": 512,
+						"previous_state": "STARTED"
+					}`),
+				}, {
+					MetaData: cf.MetaData{CreatedAt: now.Add(-28 * time.Minute)},
+					EntityRaw: json.RawMessage(`{
+						"state": "STOPPED",
+						"app_guid": "o1s1-app2",
+						"app_name": "o1s1-app1-renamed",
 						"org_guid": "o1",
 						"space_guid": "o1s1",
 						"instance_count": 2,
@@ -872,7 +896,7 @@ var _ = Describe("API", func() {
 					EntityRaw: json.RawMessage(`{
 						"state": "STOPPED",
 						"app_guid": "o2s1-app1",
-						"app_name": "o2s1-app1",
+						"app_name": "o2s1-app1-renamed",
 						"org_guid": "o2",
 						"space_guid": "o1s2",
 						"instance_count": 2,
@@ -898,7 +922,7 @@ var _ = Describe("API", func() {
 					EntityRaw: json.RawMessage(`{
 						"state": "DELETED",
 						"service_instance_guid": "o2s1-db1",
-						"service_instance_name": "o2s1-db1",
+						"service_instance_name": "o2s1-db1-renamed",
 						"org_guid": "o2",
 						"space_guid": "o2s1",
 						"service_plan_guid": "` + X2ServicePlan.PlanGuid + `",
@@ -920,7 +944,7 @@ var _ = Describe("API", func() {
 					EntityRaw: json.RawMessage(`{
 						"state": "DELETED",
 						"service_instance_guid": "o1s1-db1",
-						"service_instance_name": "o1s1-db1",
+						"service_instance_name": "o1s1-db1-renamed",
 						"org_guid": "o1",
 						"space_guid": "o1s1",
 						"service_plan_guid": "` + X2ServicePlan.PlanGuid + `",
@@ -969,7 +993,7 @@ var _ = Describe("API", func() {
 			Expect(res.StatusCode).To(Equal(http.StatusOK), string(body))
 
 			type ResourceReport struct {
-				Guid  string `json:"guid"`
+				Name  string `json:"name"`
 				Price int64  `json:"price"`
 			}
 			type SpaceReport struct {
@@ -989,18 +1013,18 @@ var _ = Describe("API", func() {
 
 			expectedOutput := OrgReport{
 				OrgGuid: "o1",
-				Price:   1800000,
+				Price:   3240000,
 				Spaces: []SpaceReport{
 					{
 						SpaceGuid: "o1s1",
-						Price:     1800000,
+						Price:     3240000,
 						Resources: []ResourceReport{
 							{
-								Guid:  "o1s1-app1",
-								Price: 1440000,
+								Name:  "o1s1-app1",
+								Price: 2880000,
 							},
 							{
-								Guid:  "o1s1-db1",
+								Name:  "o1s1-db1",
 								Price: 360000,
 							},
 						},

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -824,6 +824,11 @@ var _ = Describe("API", func() {
 
 	Context("Billing report", func() {
 
+		var (
+			org_guid = "o1"
+			path     = "/report/" + org_guid
+		)
+
 		It("should produce a report", func() {
 			appEvents := []cf.UsageEvent{
 				{
@@ -846,6 +851,30 @@ var _ = Describe("API", func() {
 						"app_name": "o1s1-app1",
 						"org_guid": "o1",
 						"space_guid": "o1s1",
+						"instance_count": 2,
+						"memory_in_mb_per_instance": 512,
+						"previous_state": "STARTED"
+					}`),
+				}, {
+					MetaData: cf.MetaData{CreatedAt: now.Add(-49 * time.Minute)},
+					EntityRaw: json.RawMessage(`{
+						"state": "STARTED",
+						"app_guid": "o2s1-app1",
+						"app_name": "o2s1-app1",
+						"org_guid": "o2",
+						"space_guid": "o1s2",
+						"instance_count": 2,
+						"memory_in_mb_per_instance": 512,
+						"previous_state": "STOPPED"
+					}`),
+				}, {
+					MetaData: cf.MetaData{CreatedAt: now.Add(-12 * time.Minute)},
+					EntityRaw: json.RawMessage(`{
+						"state": "STOPPED",
+						"app_guid": "o2s1-app1",
+						"app_name": "o2s1-app1",
+						"org_guid": "o2",
+						"space_guid": "o1s2",
 						"instance_count": 2,
 						"memory_in_mb_per_instance": 512,
 						"previous_state": "STARTED"
@@ -921,7 +950,7 @@ var _ = Describe("API", func() {
 			err = sqlClient.UpdateViews()
 			Expect(err).ToNot(HaveOccurred())
 
-			u, err := url.Parse("/report?from=2001-01-01T00:00:00Z&to=" + now.Add(72*time.Hour).Format(time.RFC3339))
+			u, err := url.Parse(path + "?from=2001-01-01T00:00:00Z&to=" + now.Add(72*time.Hour).Format(time.RFC3339))
 			Expect(err).ToNot(HaveOccurred())
 
 			req, err := http.NewRequest("GET", u.String(), nil)
@@ -954,43 +983,25 @@ var _ = Describe("API", func() {
 				Spaces  []SpaceReport `json:"spaces"`
 			}
 
-			var actualOutput []OrgReport
+			var actualOutput OrgReport
 			err = json.Unmarshal(body, &actualOutput)
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to unmarshal json: %s\nbody: %s", err, string(body)))
 
-			expectedOutput := []OrgReport{
-				{
-					OrgGuid: "o1",
-					Price:   1800000,
-					Spaces: []SpaceReport{
-						{
-							SpaceGuid: "o1s1",
-							Price:     1800000,
-							Resources: []ResourceReport{
-								{
-									Guid:  "o1s1-app1",
-									Price: 1440000,
-								},
-								{
-									Guid:  "o1s1-db1",
-									Price: 360000,
-								},
+			expectedOutput := OrgReport{
+				OrgGuid: "o1",
+				Price:   1800000,
+				Spaces: []SpaceReport{
+					{
+						SpaceGuid: "o1s1",
+						Price:     1800000,
+						Resources: []ResourceReport{
+							{
+								Guid:  "o1s1-app1",
+								Price: 1440000,
 							},
-						},
-					},
-				},
-				{
-					OrgGuid: "o2",
-					Price:   120000,
-					Spaces: []SpaceReport{
-						{
-							SpaceGuid: "o2s1",
-							Price:     120000,
-							Resources: []ResourceReport{
-								{
-									Guid:  "o2s1-db1",
-									Price: 120000,
-								},
+							{
+								Guid:  "o1s1-db1",
+								Price: 360000,
 							},
 						},
 					},
@@ -998,7 +1009,5 @@ var _ = Describe("API", func() {
 			}
 			Expect(actualOutput).To(Equal(expectedOutput))
 		})
-
 	})
-
 })

--- a/api/ui.go
+++ b/api/ui.go
@@ -185,7 +185,7 @@ var templates = map[string]string{
 			Showing breakdown of resource usage between <strong>{{ $from }}</strong> to <strong>{{ $to }}</strong>
 		</p>
 
-		<form method="GET" action="/report" style="margin-bottom:30px;">
+		<form method="GET" action="{{ .Path }}" style="margin-bottom:30px;">
 			<div style="padding: 20px; margin:2px; background:white; overflow:hidden">
 				<div class="form-group" style="float:left; width: 25%; margin-right:40px;">
 					<label class="form-label" for="rangeFrom">From date</label>
@@ -316,11 +316,12 @@ var compiledTemplates = compile(templates)
 
 // Render renders the JSON data as HTML
 func Render(c echo.Context, r io.Reader, rt int) error {
-	name := c.Path()
-	tmpl, ok := compiledTemplates[name]
+	tmpl, ok := compiledTemplates[c.Path()]
 	if !ok {
 		tmpl = compiledTemplates["default"]
 	}
+
+	name := c.Request().URL.Path
 	return tmpl.Execute(c.Response(), &Data{
 		Title: name,
 		Path:  name,

--- a/api/ui.go
+++ b/api/ui.go
@@ -234,8 +234,12 @@ var templates = map[string]string{
 				<div class="org org-total">
 					<table>
 						<tr>
-							<td><strong>Org total</strong></td>
-							<td class="price">{{ index $org "price" | in_pounds}}</td>
+							{{ if index $org "spaces" }}
+								<td><strong>Org total</strong></td>
+								<td class="price">{{ index $org "price" | in_pounds}}</td>
+							{{ else }}
+								<td><strong>No resources found for organisation</strong>
+							{{ end }}
 						</tr>
 					</table>
 				</div>

--- a/api/ui.go
+++ b/api/ui.go
@@ -224,14 +224,14 @@ var templates = map[string]string{
 									<td class="price">{{ index $resource "price" | in_pounds}}</td>
 								</tr>
 							{{ end }}
-							<tr class="resource">
+							<tr class="space space-total">
 								<td colspan="2"><strong>Space total</strong></td>
 								<td class="price">{{ index $space "price" | in_pounds }}</td>
 							</tr>
 						</table>
 					</div>
 				{{ end }}
-				<div class="space space-total">
+				<div class="org org-total">
 					<table>
 						<tr>
 							<td><strong>Org total</strong></td>

--- a/api/ui.go
+++ b/api/ui.go
@@ -177,7 +177,7 @@ var templates = map[string]string{
 			<a href="/pricing_plans">view all plans</a>
 		</div>
 	`,
-	"/report": `
+	"/report/:org_guid": `
 		{{ $from := .Range.From }}
 		{{ $to := .Range.To }}
 

--- a/api/ui.go
+++ b/api/ui.go
@@ -219,14 +219,13 @@ var templates = map[string]string{
 							</tr>
 							{{ range $resource := index $space "resources" }}
 								<tr class="resource">
-									<td>{{ index $resource "guid" | name }}</td>
+									<td>{{ index $resource "name" }}</td>
 									<td>{{ index $resource "pricing_plan_name" }}</td>
-									<td><a href="/resources/{{ index $resource "guid" }}/events?from={{ $from }}&to={{ $to }}">details</a></td>
 									<td class="price">{{ index $resource "price" | in_pounds}}</td>
 								</tr>
 							{{ end }}
 							<tr class="resource">
-								<td colspan="3"><strong>Space total</strong></td>
+								<td colspan="2"><strong>Space total</strong></td>
 								<td class="price">{{ index $space "price" | in_pounds }}</td>
 							</tr>
 						</table>
@@ -293,14 +292,6 @@ var templateFunctions = template.FuncMap{
 			spaces, _ := cf.GetSpaces()
 			for guid, space := range spaces {
 				nameCacheMap[guid] = space.Name
-			}
-			apps, _ := cf.GetApps()
-			for guid, app := range apps {
-				nameCacheMap[guid] = app.Name
-			}
-			srvs, _ := cf.GetServiceInstances()
-			for guid, srv := range srvs {
-				nameCacheMap[guid] = srv.Name
 			}
 		}
 		name, ok := nameCacheMap[guid]

--- a/api/ui.go
+++ b/api/ui.go
@@ -55,8 +55,8 @@ var baseTemplate = `
 	<body>
 		<div class="phase-banner">
 			<p>
-				<strong class="phase-tag">ALPHA</strong>
-				<span>This is a pre-release tool</span> – Don't rely on this data!
+				<strong class="phase-tag">Beta</strong>
+				<span>Thank you for your custom</span>
 			</p>
 		</div>
 		<h1 class="heading-xlarge" style="margin:40px 10px">

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/alphagov/paas-usage-events-collector/api"
@@ -36,7 +37,6 @@ func New(db db.SQLClient, authority auth.Authenticator, cf cloudfoundry.Client) 
 	e.GET("/usage", api.NewUsageHandler(db))
 
 	e.GET("/report/:org_guid", api.NewReportHandler(db))
-	e.GET("/", redirectToReport)
 
 	// Usage and Billing API
 	e.GET("/organisations", api.ListOrgUsage(db))
@@ -59,12 +59,16 @@ func New(db db.SQLClient, authority auth.Authenticator, cf cloudfoundry.Client) 
 	e.DELETE("/pricing_plans/:pricing_plan_id", auth.AdminOnly(api.DestroyPricingPlan(db)))
 	e.POST("/seed_pricing_plans", auth.AdminOnly(api.CreateMissingPricingPlans(db)))
 
+	e.GET("/", listRoutes)
+
 	return e
 }
 
-func redirectToReport(c echo.Context) error {
-	lastMonth := time.Now().UTC().Add(-30 * 24 * time.Hour).Format(time.RFC3339)
-	return c.Redirect(http.StatusFound, "/report?from="+lastMonth)
+func listRoutes(c echo.Context) error {
+	routes := c.Echo().Routes()
+	sort.Slice(routes, func(i, j int) bool { return routes[i].Path < routes[j].Path })
+
+	return c.JSONPretty(http.StatusOK, routes, "  ")
 }
 
 func ListenAndServe(ctx context.Context, e *echo.Echo, addr string) {

--- a/server/server.go
+++ b/server/server.go
@@ -35,8 +35,7 @@ func New(db db.SQLClient, authority auth.Authenticator, cf cloudfoundry.Client) 
 	// Deprecated endpoint, favor /resources and /events
 	e.GET("/usage", api.NewUsageHandler(db))
 
-	// An example billing renderer... throw this away
-	e.GET("/report", api.NewReportHandler(db))
+	e.GET("/report/:org_guid", api.NewReportHandler(db))
 	e.GET("/", redirectToReport)
 
 	// Usage and Billing API


### PR DESCRIPTION
## What

We have added a reporting / billing endpoint that is filtered by Organisation GUID, this simplifies the bill generation process significantly and can now be performed by the Product team using any set of dates.

## How to review

**This requires production access to test**

### Dump production billing data

```
./scripts/cf_subshell_scoped_login.sh prod
cf target -o admin -s billing
cf conduit billing-db -- \
  docker run -ti \
    -e PGDATABASE \
    -e PGUSER \
    -e PGPASSWORD \
    -e PGPORT \
    -e PGHOST=docker.for.mac.localhost \
    --name billing-dump \
    postgres:9.6-alpine \
    pg_dump -Fc -f billing.dump
docker cp billing-dump:billing.dump .
docker rm -f billing-dump
```

### Start the database server

```
docker run --name billing -e POSTGRES_PASSWORD= -p 5432:5432 -d postgres:9.6-alpine
```

### Import the billing data dump
```
docker cp billing.dump billing:/
docker exec -ti billing pg_restore --create --clean --no-privileges --no-owner -f billing.sql billing.dump
vi billing.sql # remove reassign_owned() references
docker exec -ti billing sh -c 'psql -U postgres < billing.sql'
```

### Change client in your dev environment
```
cd scripts && bundle exec uaac client update paas-usage-events-collector --redirect_uri http://localhost:8881/oauth/callback
```

### Run the billing app locally
```
DATABASE_URL=postgres://postgres:@localhost:5432/rdsbroker_b946a69b_76f4_4cbc_80df_5cee2d54b7ad?sslmode=disable make run-dev
```

### Local testing
Visit the `/report/55b1eb7d-e4c5-4359-9466-dd3ca5b0e457` endpoint
With a date range set to 2017-01-01T00:00:00Z to 2018-01-01T00:00:00Z you should see an org total of £5504.69

## Who can review

Anyone with production access, but not @LeePort or @dcarley 
